### PR TITLE
BuildFixforStringFormatErrorforPpc64le

### DIFF
--- a/hbase-rest/src/main/java/org/apache/hadoop/hbase/rest/filter/RestCsrfPreventionFilter.java
+++ b/hbase-rest/src/main/java/org/apache/hadoop/hbase/rest/filter/RestCsrfPreventionFilter.java
@@ -87,9 +87,9 @@ public class RestCsrfPreventionFilter implements Filter {
       agents = BROWSER_USER_AGENTS_DEFAULT;
     }
     parseBrowserUserAgents(agents);
-    LOG.info("Adding cross-site request forgery (CSRF) protection, "
-        + "headerName = {}, methodsToIgnore = {}, browserUserAgents = {}",
-        headerName, methodsToIgnore, browserUserAgents);
+    LOG.info(String.format("Adding cross-site request forgery (CSRF) protection, "
+        + "headerName = %s, methodsToIgnore = %s, browserUserAgents = %s",
+        headerName, methodsToIgnore, browserUserAgents));
   }
 
   void parseBrowserUserAgents(String userAgents) {


### PR DESCRIPTION
Hi,

While building Hbase for HDP 2.5.0 using jdk 1.7 for RHEL ppc64le, got below error:
Build error:error: no suitable method found for info(String,String,Set,Set)

Fix: It is string format issue and so I have added format specifier.
Have picked part of code for this fix from "https://github.com/apache/hbase/commit/3d7840a173aab97fb72409fa8c0f161fd7ad0e8f"

Thanks & Regards,
Sonali Shrivastava
